### PR TITLE
Fix SpectrumSampler in Python extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,10 @@
 #  NOTE: on Fedora, need to link blas and lapack properly, where X.X.X is some version numbers
 #  Linking Command Example: sudo ln -s /usr/lib64/liblapack.so.X.X.X /usr/lib64/liblapack.so
 #  blas Example: sudo ln -s /usr/lib64/libopeblas64.so.X.X.X /usr/lib64/libblas.so
-#  Can also use -L to link to the explicit libary path 
+#  Can also use -L to link to the explicit libary path
+#  For example to use blas/lapack or even mkl installed in a anaconda conda environment:
+# BLAS_LIB = -L$(CONDA_PREFIX)/lib/ -lmkl_core -lmkl_rt -lstdc++ -lpthread -lm -ldl
+# LAPACK_LIB = -L$(CONDA_PREFIX)/lib/ -lmkl_core -lmkl_rt -lstdc++ -lpthread -lm -ldl
 BLAS_LIB = -lblas
 LAPACK_LIB = -llapack
 
@@ -33,14 +36,18 @@ LUA_LIB = -L./lua-5.2.4/install/lib -llua -ldl -lm
 #  or, if Fedora and/or fftw is version 3 but named fftw rather than fftw3
 #  FTW3_LIB = -lfftw 
 #  May need to link libraries properly as with blas and lapack above
+# FFTW3_INC = -I$(CONDA_PREFIX)/include/
+# FFTW3_LIB = -L$(CONDA_PREFIX)/lib/ -lfftw3
 FFTW3_INC =
 FFTW3_LIB = -lfftw3
 
 # Typically,
 #  PTHREAD_INC = -DHAVE_UNISTD_H
 #  PTHREAD_LIB = -lpthread
+# If conda env
+# PTHREAD_LIB = -L$(CONDA_PREFIX)/lib/ -lpthread
 PTHREAD_INC = -DHAVE_UNISTD_H
-PTHREAD_LIB = -lpthread
+#PTHREAD_LIB = -lpthread
 
 # OPTIONAL
 # If not installed:
@@ -48,6 +55,9 @@ PTHREAD_LIB = -lpthread
 # Typically, if installed:
 #CHOLMOD_INC = -I/usr/include/suitesparse
 #CHOLMOD_LIB = -lcholmod -lamd -lcolamd -lcamd -lccolamd
+# Alternate Example: I compiled and istalled SuiteSpares in the directory above this S4 directory
+# CHOLMOD_INC = -I../SuiteSparse/include/
+# CHOLMOD_LIB = -L../SuiteSparse/lib/ -lcholmod -lamd -lcolamd -lcamd -lccolamd
 CHOLMOD_INC = -I/usr/include/suitesparse
 CHOLMOD_LIB = -lcholmod -lamd -lcolamd -lcamd -lccolamd
 
@@ -71,7 +81,7 @@ CXX = g++
 CC  = gcc
 
 #CFLAGS += -O3 -fPIC
-CFLAGS = -Wall -O3 -msse3 -msse2 -msse -fPIC
+CFLAGS = -Wall -O3 -m64 -march=native -mtune=native -msse3 -msse2 -msse -fPIC
 
 # options for Sampler module
 OPTFLAGS = -O3

--- a/S4/main_python.c
+++ b/S4/main_python.c
@@ -598,7 +598,7 @@ static PyObject *S4SpectrumSampler_new(PyTypeObject *type, PyObject *args, PyObj
 	SpectrumSampler_Options options = {33, 0.001, 10, 1e-6, 0};
 	PyObject *py_expectBool = NULL;
 	S4SpectrumSampler *self;
-	if(!PyArg_ParseTupleAndKeywords(args, kwds, "dd|i|d|d|d|O!:SpectrumSampler_New", \
+	if(!PyArg_ParseTupleAndKeywords(args, kwds, "dd|idddO!:SpectrumSampler_New", \
 		kwlist, &x0, &x1, &options.initial_num_points, &options.range_threshold,\
 		&options.max_bend, &options.min_dx, &PyBool_Type, &py_expectBool))
 		return NULL;
@@ -1929,7 +1929,11 @@ static PyObject *S4SpectrumSampler_GetSpectrum(S4SpectrumSampler *self, PyObject
 	for(int i = 0; i < n; i++)
 	{
 		SpectrumSampler_Enumerator_Get(e, pt);
-		PyTuple_SetItem(retObj, i, PyTuple_Pack(2, pt[0], pt[1]));
+		PyTuple_SetItem(retObj, i, PyTuple_Pack(2,
+				                                PyFloat_FromDouble(pt[0]),
+				                                PyFloat_FromDouble(pt[1])
+				                                ));
+
 	}
 	return retObj;
 }


### PR DESCRIPTION
Python Extension: Fixed passing the necessary keyword arguments to the SpectrumSampler Corrected type conversion before returning SpectrumSampler Spectrum