### PR TITLE
fix compilation error: signed comparison with pointer

### DIFF
--- a/S4/S4.cpp
+++ b/S4/S4.cpp
@@ -429,7 +429,7 @@ int Simulation_ChangeLayerThickness(Simulation *S, Layer *layer, const double *t
 	int ret = 0;
 	if(NULL == S){ ret = -1; }
 	if(NULL == layer){ ret = -2; }
-	if(thick < 0){ ret = -3; }
+	if(NULL == thick || *thick < 0){ ret = -3; }
 	if(0 != ret){
 		S4_TRACE("< Simulation_RemoveLayerPatterns (failed; ret = %d) [omega=%f]\n", ret, S->omega[0]);
 		return ret;


### PR DESCRIPTION
`thick` is a pointer, therefore signed comparison doesn't really make sense. The error:

```
MacBook:S4 markus$ make S4_pyext
mkdir -p ./build
mkdir -p ./build/S4k
mkdir -p ./build/S4r
mkdir -p ./build/modules
g++ -c -O3 -msse3 -msse2 -msse -fPIC -I. -IS4 -IS4/RNP -IS4/kiss_fft -DHAVE_BLAS -DHAVE_LAPACK -DHAVE_LIBPTHREAD -DHAVE_UNISTD_H S4/S4.cpp -o build/S4k/S4.o
S4/S4.cpp:432:11: error: ordered comparison between pointer and zero ('const double *' and 'int')
        if(thick < 0){ ret = -3; }
           ~~~~~ ^ ~
1 error generated.
make: *** [build/S4k/S4.o] Error 1
```

on line 432:

https://github.com/phoebe-p/S4/blob/363411d0b2d007151700c7a249f4804320dc290c/S4/S4.cpp#L426-L443