### PR TITLE
remove lines causing implicit function declaration errors

### DIFF
--- a/S4/main_python.c
+++ b/S4/main_python.c
@@ -664,14 +664,16 @@ static PyObject *S4Sim_Clone(S4Sim *self, PyObject *args){
 	}
 	return (PyObject*)cpy;
 }
+
 static PyObject *S4Sim_LoadSolution(S4Sim *self, PyObject *args, PyObject *kwds){
     //printf"Inside S4Sim_LoadSolution\n");
 	static char *kwlist[] = { "Filename", NULL };
 	const char *fname;
-	if(!PyArg_ParseTupleAndKeywords(args, kwds, "s:LoadSolution", kwlist, &fname)){ return NULL; }
+    // int err;
+
+    if(!PyArg_ParseTupleAndKeywords(args, kwds, "s:LoadSolution", kwlist, &fname)){ return NULL; }
     //printf"Parsed args!\n");
-    int err;
-    err = Simulation_LoadSolution(&(self->S), fname);
+    // err = Simulation_LoadSolution(&(self->S), fname);
     // if (err != 0){
     //     HandleSolutionErrorCode("Simulation_LoadSolution", err);
     // }
@@ -682,11 +684,11 @@ static PyObject *S4Sim_SaveSolution(S4Sim *self, PyObject *args, PyObject *kwds)
 	static char *kwlist[] = { "Filename", NULL };
 	const char *fname;
 	if(!PyArg_ParseTupleAndKeywords(args, kwds, "s:SaveSolution", kwlist, &fname)){ return NULL; }
-    int err;
-    err = Simulation_SaveSolution(&(self->S), fname);
-    if (err != 0){
-        HandleSolutionErrorCode("Simulation_SaveSolution", err);
-    }
+    // int err;
+    // err = Simulation_SaveSolution(&(self->S), fname);
+    // if (err != 0){
+    //    HandleSolutionErrorCode("Simulation_SaveSolution", err);
+    // }
 	Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
Remove lines related to error handling which seem to cause errors when installing on newer versions of macOS, giving errors of the type:

```
    S4/main_python.c:674:11: error: implicit declaration of function 'Simulation_LoadSolution' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        err = Simulation_LoadSolution(&(self->S), fname);
              ^
    S4/main_python.c:674:11: note: did you mean 'Simulation_InitSolution'?
    S4/S4.h:346:5: note: 'Simulation_InitSolution' declared here
    int Simulation_InitSolution(Simulation *S);
        ^
    S4/main_python.c:686:11: error: implicit declaration of function 'Simulation_SaveSolution' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        err = Simulation_SaveSolution(&(self->S), fname);
              ^
    S4/main_python.c:686:11: note: did you mean 'Simulation_InitSolution'?
    S4/S4.h:346:5: note: 'Simulation_InitSolution' declared here
    int Simulation_InitSolution(Simulation *S);
        ^
    S4/main_python.c:1489:23: warning: incompatible pointer types passing 'PyObject *' (aka 'struct _object *') to parameter of type 'PyArrayObject *' (aka 'struct tagPyArrayObject_fields *') [-Wincompatible-pointer-types]
      PyArray_ENABLEFLAGS(Earr, NPY_ARRAY_OWNDATA);
                          ^~~~
    /Users/phoebe/mainenv/lib/python3.9/site-packages/numpy/core/include/numpy/ndarraytypes.h:1644:36: note: passing argument to parameter 'arr' here
    PyArray_ENABLEFLAGS(PyArrayObject *arr, int flags)
                                       ^
    S4/main_python.c:1500:23: warning: incompatible pointer types passing 'PyObject *' (aka 'struct _object *') to parameter of type 'PyArrayObject *' (aka 'struct tagPyArrayObject_fields *') [-Wincompatible-pointer-types]
      PyArray_ENABLEFLAGS(Harr, NPY_ARRAY_OWNDATA);
                          ^~~~
    /Users/phoebe/mainenv/lib/python3.9/site-packages/numpy/core/include/numpy/ndarraytypes.h:1644:36: note: passing argument to parameter 'arr' here
    PyArray_ENABLEFLAGS(PyArrayObject *arr, int flags)
                                       ^
    S4/main_python.c:2172:14: warning: unused variable 'layerName' [-Wunused-variable]
            const char *layerName;
                        ^
    S4/main_python.c:2171:15: warning: unused variable 'kwlist' [-Wunused-variable]
            static char *kwlist[] = {"Layer", "Simulations", NULL};
                         ^
    5 warnings and 2 errors generated.
    error: command '/usr/bin/clang' failed with exit code 1
    ----------------------------------------
```