### PR TITLE
Add Apple M1 makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,9 +91,9 @@ S4_BINNAME = $(OBJDIR)/S4
 S4_LIBNAME = $(OBJDIR)/libS4.a
 S4r_LIBNAME = $(OBJDIR)/libS4r.a
 
-#### Download, compile, and install boost serialization lib. 
+#### Download, compile, and install boost serialization lib.
 #### This should all work fine, you must modify BOOST_INC, BOOST_LIBS,
-#### and PREFIX if you want to install boost to a different location 
+#### and PREFIX if you want to install boost to a different location
 
 # Specify the paths to the boost include and lib directories
 BOOST_PREFIX=${CURDIR}/S4
@@ -106,7 +106,7 @@ $(BOOST_FILE):
 	wget $(BOOST_URL) -O $(BOOST_FILE)
 
 # Target for extracting boost from archive and compiling. Depends on download target above
-${CURDIR}/S4/lib: $(BOOST_FILE)  
+${CURDIR}/S4/lib: $(BOOST_FILE)
 	$(eval BOOST_DIR := $(shell tar tzf $(BOOST_FILE) | sed -e 's@/.*@@' | uniq))
 	@echo Boost dir is $(BOOST_DIR)
 	tar -xzvf $(BOOST_FILE)
@@ -120,32 +120,32 @@ boost: $(BOOST_PREFIX)/lib
 
 #### Set the compilation flags
 
-CPPFLAGS = -Wall -I. -IS4 -IS4/RNP -IS4/kiss_fft 
- 
+CPPFLAGS = -Wall -I. -IS4 -IS4/RNP -IS4/kiss_fft
+
 ifeq ($(S4_PROF), 1)
 CPPFLAGS += -g -pg
 endif
 
 ifeq ($(S4_DEBUG), 1)
-CPPFLAGS += -ggdb 
+CPPFLAGS += -ggdb
 endif
 
 ifeq ($(S4_DEBUG), 2)
 CPPFLAGS += -DENABLE_S4_TRACE
-CPPFLAGS += -ggdb 
+CPPFLAGS += -ggdb
 endif
 
 ifeq ($(S4_DEBUG), 3)
 CPPFLAGS += -DENABLE_S4_TRACE
 CPPFLAGS += -DDUMP_MATRICES
-CPPFLAGS += -ggdb 
+CPPFLAGS += -ggdb
 endif
 
 ifeq ($(S4_DEBUG), 4)
 CPPFLAGS += -DENABLE_S4_TRACE
 CPPFLAGS += -DDUMP_MATRICES
 CPPFLAGS += -DDUMP_MATRICES_LARGE
-CPPFLAGS += -ggdb 
+CPPFLAGS += -ggdb
 endif
 
 ifdef BOOST_INC
@@ -188,7 +188,7 @@ objdir:
 	mkdir -p $(OBJDIR)/S4k
 	mkdir -p $(OBJDIR)/S4r
 	mkdir -p $(OBJDIR)/modules
-	
+
 S4_LIBOBJS = \
 	$(OBJDIR)/S4k/S4.o \
 	$(OBJDIR)/S4k/rcwa.o \
@@ -288,7 +288,7 @@ $(OBJDIR)/S4k/convert.o: S4/convert.c
 $(OBJDIR)/S4k/Eigensystems.o: S4/RNP/Eigensystems.cpp
 	$(CXX) -c $(CFLAGS) $(CPPFLAGS) $< -o $@
 
-	
+
 
 
 $(OBJDIR)/S4r/Material.o: S4r/Material.cpp S4r/Material.hpp S4r/Types.hpp
@@ -315,11 +315,11 @@ $(OBJDIR)/S4r/IRA.o: S4r/IRA.cpp S4r/IRA.hpp S4r/Types.hpp
 	$(CXX) -c $(CFLAGS) $(CPPFLAGS) -I. $< -o $@
 $(OBJDIR)/S4r/intersection.o: S4r/intersection.c S4r/intersection.h
 	$(CC) -c -O3 $< -o $@
-$(OBJDIR)/S4r/periodic_off2.o: S4r/periodic_off2.c S4r/periodic_off2.h 
+$(OBJDIR)/S4r/periodic_off2.o: S4r/periodic_off2.c S4r/periodic_off2.h
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@
 $(OBJDIR)/S4r/predicates.o: S4r/predicates.c
 	$(CC) -c -O3 $< -o $@
-	
+
 #### Lua Frontend
 
 $(OBJDIR)/S4k/main_lua.o: S4/main_lua.c objdir

--- a/Makefile.m1
+++ b/Makefile.m1
@@ -1,53 +1,87 @@
 # To build:
 #   make <target>
-# Use either 'S4lua' for Lua, or 'python_ext' for Python.
-# S4lua also builds FunctionSampler1D and FunctionSampler2D, in modules.
-# You can build the sampler seperately with 'make sampler'
+# Use the 'lib' target first to build the library, then either the Lua
+# or Python targets are 'S4lua' and 'python_ext', respectively.
 
 # Set these to the flags needed to link against BLAS and Lapack.
 #  If left blank, then performance may be very poor.
-BLAS_LIB = -framework Accelerate
-LAPACK_LIB = -framework Accelerate
+#  On Mac OS,
+#   BLAS_LIB = -framework vecLib
+#   LAPACK_LIB = -framework vecLib
+#  On Fedora: dnf install openblas-devel
+#  On Debian and Fedora, with reference BLAS and Lapack (slow)
+#   BLAS_LIB = -lblas
+#   LAPACK_LIB = -llapack
+#  NOTE: on Fedora, need to link blas and lapack properly, where X.X.X is some version numbers
+#  Linking Command Example: sudo ln -s /usr/lib64/liblapack.so.X.X.X /usr/lib64/liblapack.so
+#  blas Example: sudo ln -s /usr/lib64/libopeblas64.so.X.X.X /usr/lib64/libblas.so
+#  Can also use -L to link to the explicit libary path
+#  For example to use blas/lapack or even mkl installed in a anaconda conda environment:
+# BLAS_LIB = -L$(CONDA_PREFIX)/lib/ -lmkl_core -lmkl_rt -lstdc++ -lpthread -lm -ldl
+# LAPACK_LIB = -L$(CONDA_PREFIX)/lib/ -lmkl_core -lmkl_rt -lstdc++ -lpthread -lm -ldl
+BLAS_LIB = -lblas
+LAPACK_LIB = -llapack
 
 # Specify the flags for Lua headers and libraries (only needed for Lua frontend)
 # Recommended: build lua in the current directory, and link against this local version
 # LUA_INC = -I./lua-5.2.4/install/include
-# LUA_LIB = -L./lua-5.2.4/install/lib -llua -ldl
-# LUA_INC = -I./lua-5.2.4/install/include
-# LUA_LIB = -L./lua-5.2.4/install/lib -llua -ldl
+# LUA_LIB = -L./lua-5.2.4/install/lib -llua -ldl -lm
+LUA_INC = -I./lua-5.2.4/install/include
+LUA_LIB = -L./lua-5.2.4/install/lib -llua -ldl -lm
 
-# Typically if installed (use Homebrew, brew install fftw),
+# OPTIONAL
+# Typically if installed,
 #  FFTW3_INC can be left empty
-#  FFTW3_LIB = -lfftw3
-FFTW3_INC = -I/usr/local/include
+#  FFTW3_LIB = -lfftw3 
+#  or, if Fedora and/or fftw is version 3 but named fftw rather than fftw3
+#  FTW3_LIB = -lfftw 
+#  May need to link libraries properly as with blas and lapack above
+# FFTW3_INC = -I$(CONDA_PREFIX)/include/
+# FFTW3_LIB = -L$(CONDA_PREFIX)/lib/ -lfftw3
+FFTW3_INC =
 FFTW3_LIB = -lfftw3
 
 # Typically,
-#  PTHREAD_INC = -DHAVE_UNISTD_H -lpthread
+#  PTHREAD_INC = -DHAVE_UNISTD_H
 #  PTHREAD_LIB = -lpthread
-PTHREAD_INC =  -DHAVE_UNISTD_H
-PTHREAD_LIB = -lpthread
+# If conda env
+# PTHREAD_LIB = -L$(CONDA_PREFIX)/lib/ -lpthread
+PTHREAD_INC = -DHAVE_UNISTD_H
+#PTHREAD_LIB = -lpthread
 
-# Typically if installed (use Home-brew, brew install suite-sparse),
-CHOLMOD_INC = -I/usr/local/include
+# OPTIONAL
+# If not installed:
+# Fedora: dnf install libsuitsparse-devel
+# Typically, if installed:
+#CHOLMOD_INC = -I/usr/include/suitesparse
+#CHOLMOD_LIB = -lcholmod -lamd -lcolamd -lcamd -lccolamd
+# Alternate Example: I compiled and istalled SuiteSpares in the directory above this S4 directory
+# CHOLMOD_INC = -I../SuiteSparse/include/
+# CHOLMOD_LIB = -L../SuiteSparse/lib/ -lcholmod -lamd -lcolamd -lcamd -lccolamd
+CHOLMOD_INC = -I/usr/include/suitesparse
 CHOLMOD_LIB = -lcholmod -lamd -lcolamd -lcamd -lccolamd
 
-
-BOOST_PREFIX=-I/usr/local
-BOOST_INC = -I$(BOOST_PREFIX)/include
-BOOST_LIBS = -L$(BOOST_PREFIX)/lib/ -lboost_serialization
-boost: $(BOOST_PREFIX)/lib
-
-
 # Specify the MPI library
-MPI_INC =
-MPI_LIB =
+# For example, on Fedora: dnf  install openmpi-devel
+#MPI_INC = -I/usr/include/openmpi-x86_64/openmpi/ompi
+#MPI_LIB = -lmpi
+# or, explicitly link to the library with -L, example below
+#MPI_LIB = -L/usr/lib64/openmpi/lib/libmpi.so
+#MPI_INC = -I/usr/include/openmpi-x86_64/openmpi
+#MPI_LIB = -L/usr/lib64/openmpi/lib/libmpi.so
+
+# Enable S4_TRACE debugging
+# values of 1, 2, 3 enable debugging, with verbosity increasing as 
+# value increases. 0 to disable
+S4_DEBUG = 0
+S4_PROF = 0
 
 # Specify custom compilers if needed
-CXX = c++
-CC  = cc
+CXX = g++
+CC  = gcc
 
-CFLAGS = -O3 -fPIC
+#CFLAGS += -O3 -fPIC
+CFLAGS = -Wall -O3 -m64 -mcpu=apple-m1 -mtune=native -fPIC
 
 # options for Sampler module
 OPTFLAGS = -O3
@@ -57,29 +91,9 @@ S4_BINNAME = $(OBJDIR)/S4
 S4_LIBNAME = $(OBJDIR)/libS4.a
 S4r_LIBNAME = $(OBJDIR)/libS4r.a
 
-#### Download, compile, and install boost serialization lib. 
-#### This should all work fine, you must modify BOOST_INC, BOOST_LIBS,
-#### and PREFIX if you want to install boost to a different location 
+BOOST_INC =
+BOOST_LIBS = -lboost_serialization
 
-# Specify the paths to the boost include and lib directories
-BOOST_PREFIX=${CURDIR}/S4
-BOOST_INC = -I$(BOOST_PREFIX)/include
-BOOST_LIBS = -L$(BOOST_PREFIX)/lib/ -lboost_serialization
-BOOST_URL=https://sourceforge.net/projects/boost/files/boost/1.61.0/boost_1_61_0.tar.gz
-BOOST_FILE=boost.tar.gz
-# Target for downloading boost from above URL
-$(BOOST_FILE):
-	wget $(BOOST_URL) -O $(BOOST_FILE)
-
-# Target for extracting boost from archive and compiling. Depends on download target above
-${CURDIR}/S4/lib: $(BOOST_FILE)  
-	$(eval BOOST_DIR := $(shell tar tzf $(BOOST_FILE) | sed -e 's@/.*@@' | uniq))
-	@echo Boost dir is $(BOOST_DIR)
-	tar -xzvf $(BOOST_FILE)
-	mv $(BOOST_DIR) boost_src
-	cd boost_src && ./bootstrap.sh --with-libraries=serialization --prefix=$(BOOST_PREFIX) && ./b2 install
-# Final target which pulls everything together
-boost: $(BOOST_PREFIX)/lib
 
 ##################### DO NOT EDIT BELOW THIS LINE #####################
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ cd S4
 make S4_pyext
 ```
 
-Running the `make boost` command before `make S4_pyext` should automatically download and compile the relevant Boost libraries in the local S4 directory. HOWEVER, this appears to cause problems on macOS, so if you are installing on macOS you should install the boost libraries using Homebrew (see below). If you want to use Boost libraries in a different location you will have to edit the Makefile.
+Running the `make boost` command before `make S4_pyext` should automatically download and compile the relevant Boost libraries in the local S4 directory. 
+HOWEVER, this appears to cause problems on macOS, so if you are installing on macOS you should install the boost libraries 
+using Homebrew (see below). If you want to use Boost libraries in a different location you will have to edit the Makefile.
+
+**Note for users of new (late 2020 onwards) Apple machines with M1/Apple silicon/ARM chips: you will need to use Makefile.m1
+to compile successfully, see notes below on how to do this.**
 
 ## Installing relevant libraries etc.:
 
@@ -50,6 +55,19 @@ to e.g.:
 You can install S4 into a virtual environment automatically by just activating that environment in your terminal before running `make S4_pyext`.
 
 See [here](https://rayflare.readthedocs.io/en/latest/Installation/installation.html) for more extensive instructions.
+
+
+**On MacOS with M1/ARM chips:**
+
+Some of the flags used in the default Makefile cause issues with the new chip architecture. Run the following instead:
+
+```
+git clone https://github.com/phoebe-p/S4
+cd S4
+make S4_pyext --file="Makefile.m1"
+```
+
+Installing the libraries with Homebrew should work as expected.
 
 -------------------------------------
 


### PR DESCRIPTION
Addresses the issue described [here](https://github.com/qpv-research-group/rayflare/issues/42). The -msse flags and code for downloading the boost libraries were also removed (now just recommend installing boost via Homebrew).