### PR TITLE
Fixed S4 build for macOS-arm64

### DIFF
--- a/Makefile.m1
+++ b/Makefile.m1
@@ -38,7 +38,7 @@ LUA_LIB = -L./lua-5.2.4/install/lib -llua -ldl -lm
 #  May need to link libraries properly as with blas and lapack above
 # FFTW3_INC = -I$(CONDA_PREFIX)/include/
 # FFTW3_LIB = -L$(CONDA_PREFIX)/lib/ -lfftw3
-FFTW3_INC =
+FFTW3_INC = -I/opt/homebrew/include/
 FFTW3_LIB = -lfftw3
 
 # Typically,
@@ -77,8 +77,8 @@ S4_DEBUG = 0
 S4_PROF = 0
 
 # Specify custom compilers if needed
-CXX = g++
-CC  = gcc
+CXX = clang++
+CC  = clang
 
 #CFLAGS += -O3 -fPIC
 CFLAGS = -Wall -O3 -m64 -mcpu=apple-m1 -mtune=native -fPIC
@@ -91,9 +91,8 @@ S4_BINNAME = $(OBJDIR)/S4
 S4_LIBNAME = $(OBJDIR)/libS4.a
 S4r_LIBNAME = $(OBJDIR)/libS4r.a
 
-BOOST_INC = -I/opt/homebrew/include/boost
+BOOST_INC = -I/opt/homebrew/include/
 BOOST_LIBS = -lboost_serialization
-# BOOST_LIBS = 
 
 ##################### DO NOT EDIT BELOW THIS LINE #####################
 
@@ -326,6 +325,8 @@ FunctionSampler2D.so: modules/function_sampler_2d.c modules/function_sampler_2d.
 	gcc $(OPTFLAGS) -shared -fpic -Wall $(LUA_INC) -o $(OBJDIR)/FunctionSampler2D.so $(OBJDIR)/modules/function_sampler_2d.o $(OBJDIR)/modules/mod_predicates.o modules/lua_function_sampler_2d.c $(LUA_LIB)
 
 #### Python extension
+
+BOOST_PREFIX = /opt/homebrew/
 
 S4_pyext: objdir $(S4_LIBNAME)
 	sh gensetup.py.sh $(OBJDIR) $(S4_LIBNAME) "$(LIBS)" $(BOOST_PREFIX)

--- a/Makefile.mac_intel
+++ b/Makefile.mac_intel
@@ -38,7 +38,7 @@ LUA_LIB = -L./lua-5.2.4/install/lib -llua -ldl -lm
 #  May need to link libraries properly as with blas and lapack above
 # FFTW3_INC = -I$(CONDA_PREFIX)/include/
 # FFTW3_LIB = -L$(CONDA_PREFIX)/lib/ -lfftw3
-FFTW3_INC =
+FFTW3_INC = -I/opt/homebrew/include/
 FFTW3_LIB = -lfftw3
 
 # Typically,
@@ -58,9 +58,17 @@ PTHREAD_INC = -DHAVE_UNISTD_H
 # Alternate Example: I compiled and istalled SuiteSpares in the directory above this S4 directory
 # CHOLMOD_INC = -I../SuiteSparse/include/
 # CHOLMOD_LIB = -L../SuiteSparse/lib/ -lcholmod -lamd -lcolamd -lcamd -lccolamd
-CHOLMOD_INC = -I/usr/local/include/suitesparse
+CHOLMOD_INC = -I/opt/homebrew/include/suitesparse
 CHOLMOD_LIB = -lcholmod -lamd -lcolamd -lcamd -lccolamd
 
+# Specify the MPI library
+# For example, on Fedora: dnf  install openmpi-devel
+#MPI_INC = -I/usr/include/openmpi-x86_64/openmpi/ompi
+#MPI_LIB = -lmpi
+# or, explicitly link to the library with -L, example below
+#MPI_LIB = -L/usr/lib64/openmpi/lib/libmpi.so
+#MPI_INC = -I/usr/include/openmpi-x86_64/openmpi
+#MPI_LIB = -L/usr/lib64/openmpi/lib/libmpi.so
 
 # Enable S4_TRACE debugging
 # values of 1, 2, 3 enable debugging, with verbosity increasing as 
@@ -83,37 +91,39 @@ S4_BINNAME = $(OBJDIR)/S4
 S4_LIBNAME = $(OBJDIR)/libS4.a
 S4r_LIBNAME = $(OBJDIR)/libS4r.a
 
+BOOST_INC = -I/opt/homebrew/include/
+BOOST_LIBS = -lboost_serialization
 ##################### DO NOT EDIT BELOW THIS LINE #####################
 
 
 #### Set the compilation flags
 
-CPPFLAGS = -Wall -I. -IS4 -IS4/RNP -IS4/kiss_fft 
- 
+CPPFLAGS = -Wall -I. -IS4 -IS4/RNP -IS4/kiss_fft
+
 ifeq ($(S4_PROF), 1)
 CPPFLAGS += -g -pg
 endif
 
 ifeq ($(S4_DEBUG), 1)
-CPPFLAGS += -ggdb 
+CPPFLAGS += -ggdb
 endif
 
 ifeq ($(S4_DEBUG), 2)
 CPPFLAGS += -DENABLE_S4_TRACE
-CPPFLAGS += -ggdb 
+CPPFLAGS += -ggdb
 endif
 
 ifeq ($(S4_DEBUG), 3)
 CPPFLAGS += -DENABLE_S4_TRACE
 CPPFLAGS += -DDUMP_MATRICES
-CPPFLAGS += -ggdb 
+CPPFLAGS += -ggdb
 endif
 
 ifeq ($(S4_DEBUG), 4)
 CPPFLAGS += -DENABLE_S4_TRACE
 CPPFLAGS += -DDUMP_MATRICES
 CPPFLAGS += -DDUMP_MATRICES_LARGE
-CPPFLAGS += -ggdb 
+CPPFLAGS += -ggdb
 endif
 
 ifdef BOOST_INC
@@ -156,7 +166,7 @@ objdir:
 	mkdir -p $(OBJDIR)/S4k
 	mkdir -p $(OBJDIR)/S4r
 	mkdir -p $(OBJDIR)/modules
-	
+
 S4_LIBOBJS = \
 	$(OBJDIR)/S4k/S4.o \
 	$(OBJDIR)/S4k/rcwa.o \
@@ -256,7 +266,7 @@ $(OBJDIR)/S4k/convert.o: S4/convert.c
 $(OBJDIR)/S4k/Eigensystems.o: S4/RNP/Eigensystems.cpp
 	$(CXX) -c $(CFLAGS) $(CPPFLAGS) $< -o $@
 
-	
+
 
 
 $(OBJDIR)/S4r/Material.o: S4r/Material.cpp S4r/Material.hpp S4r/Types.hpp
@@ -283,11 +293,11 @@ $(OBJDIR)/S4r/IRA.o: S4r/IRA.cpp S4r/IRA.hpp S4r/Types.hpp
 	$(CXX) -c $(CFLAGS) $(CPPFLAGS) -I. $< -o $@
 $(OBJDIR)/S4r/intersection.o: S4r/intersection.c S4r/intersection.h
 	$(CC) -c -O3 $< -o $@
-$(OBJDIR)/S4r/periodic_off2.o: S4r/periodic_off2.c S4r/periodic_off2.h 
+$(OBJDIR)/S4r/periodic_off2.o: S4r/periodic_off2.c S4r/periodic_off2.h
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@
 $(OBJDIR)/S4r/predicates.o: S4r/predicates.c
 	$(CC) -c -O3 $< -o $@
-	
+
 #### Lua Frontend
 
 $(OBJDIR)/S4k/main_lua.o: S4/main_lua.c objdir
@@ -314,6 +324,8 @@ FunctionSampler2D.so: modules/function_sampler_2d.c modules/function_sampler_2d.
 	gcc $(OPTFLAGS) -shared -fpic -Wall $(LUA_INC) -o $(OBJDIR)/FunctionSampler2D.so $(OBJDIR)/modules/function_sampler_2d.o $(OBJDIR)/modules/mod_predicates.o modules/lua_function_sampler_2d.c $(LUA_LIB)
 
 #### Python extension
+
+BOOST_PREFIX = /opt/homebrew/
 
 S4_pyext: objdir $(S4_LIBNAME)
 	sh gensetup.py.sh $(OBJDIR) $(S4_LIBNAME) "$(LIBS)" $(BOOST_PREFIX)


### PR DESCRIPTION
The fix consists manly in two part:

- removing the `boost` from boost path from the parameter `BOOST_INC` resulting in: `-I/opt/homebrew/include/`
- Adding the parameter `BOOST_PREFIX = /opt/homebrew/` needed for creating the wheel of S4 